### PR TITLE
Implementing an Image_Handler and Header-Styles

### DIFF
--- a/source/docx_generator/adapters/docx/style_adapter.py
+++ b/source/docx_generator/adapters/docx/style_adapter.py
@@ -16,7 +16,7 @@ _BEGIN_STYLE = re.compile(r'##\s*begin\s*style\s*(\w+)\s*##', re.IGNORECASE)
 _END_STYLE = re.compile(r'##\s*end\s*style\s*##', re.IGNORECASE)
 _TAG_STYLE = re.compile(r'##\s*(\w+)\s*##', re.IGNORECASE)
 
-PARAGRAPH_STYLE_TAGS = {'ul', 'ol', 'paragraph', 'code', 'quote', 'image_caption'}
+PARAGRAPH_STYLE_TAGS = {'ul', 'ol', 'paragraph', 'code', 'quote', 'image_caption', 'header1', 'header2', 'header3', 'header4', 'header5'}
 RAW_STYLE_TAGS = {'hyperlink', 'strong', 'italic', 'strike', 'inline_code'}
 TABLE_STYLE_TAGS = {'table', }
 
@@ -24,6 +24,12 @@ TABLE_STYLE_TAGS = {'table', }
 class DocxStyleAdapter:
     name: AnyStr
     _warnings: Set
+
+    header1: AnyStr
+    header2: AnyStr
+    header3: AnyStr
+    header4: AnyStr
+    header5: AnyStr
 
     ul: AnyStr
     ol: AnyStr
@@ -41,6 +47,11 @@ class DocxStyleAdapter:
     table: AnyStr
 
     _data = dict(
+        header1=None,
+        header2=None,
+        header3=None,
+        header4=None,
+        header5=None,
         ul=None,
         ol=None,
         paragraph=None,

--- a/source/docx_generator/adapters/mistletoe/DocxRenderer.py
+++ b/source/docx_generator/adapters/mistletoe/DocxRenderer.py
@@ -3,6 +3,7 @@ Taken and adapted from Sarna Tool
 https://github.com/rsrdesarrollo/sarna
 """
 import logging
+import re
 
 from docxtpl import DocxTemplate
 from mistletoe.base_renderer import BaseRenderer
@@ -71,6 +72,9 @@ class DocxRenderer(BaseRenderer):
     @debug_token_rendering('Rendering Link.')
     def render_link(self, token):
         target = escape_url(token.target)
+
+        for child in token.children:
+            child.content = re.sub(r'<.*?>', '', child.content).strip()
 
         self._suppress_rtag_stack.append(True)
         inner = self.render_inner(token)

--- a/source/docx_generator/adapters/mistletoe/DocxRenderer.py
+++ b/source/docx_generator/adapters/mistletoe/DocxRenderer.py
@@ -12,6 +12,7 @@ from docx_generator.adapters.docx.docx_adapter import make_run, escape_url, make
     make_table, make_table_row, make_table_cell, make_hyperlink_run
 from docx_generator.adapters.docx.style_adapter import DocxStyleAdapter
 from docx_generator.adapters.logging_adapter import debug_token_rendering
+from docx_generator.globals.picture_globals import PictureGlobals
 
 
 class DocxRenderer(BaseRenderer):
@@ -24,10 +25,11 @@ class DocxRenderer(BaseRenderer):
         self.warnings = set()
         return self
 
-    def __init__(self, docx: DocxTemplate):
+    def __init__(self, docx: DocxTemplate, image_handler: PictureGlobals = None):
         self.warnings = set()
         self.style = None
         self._template = docx
+        self._image_handler = image_handler
         self._suppress_ptag_stack = [False]
         self._suppress_rtag_stack = [False]
         self._list_style_stack = []
@@ -64,9 +66,12 @@ class DocxRenderer(BaseRenderer):
     def render_strikethrough(self, token):
         return self._render_standard_run(token, 'strike')
 
-    @debug_token_rendering('Rendering Image. NOT IMPLEMENTED.')
+    @debug_token_rendering('Rendering Image.')
     def render_image(self, token):
-        self.warnings.add('Markdown image is not implemented. It will be ignored')
+        if self._image_handler != None:
+            self._image_handler.set_template(self._template)
+            image = self._image_handler.add_picture(token.src)
+            return str(image)
         return ''
 
     @debug_token_rendering('Rendering Link.')

--- a/source/docx_generator/adapters/mistletoe/DocxRenderer.py
+++ b/source/docx_generator/adapters/mistletoe/DocxRenderer.py
@@ -91,10 +91,10 @@ class DocxRenderer(BaseRenderer):
         else:
             return make_run('', text)
 
-    @debug_token_rendering('Rendering Heading. NOT IMPLEMENTED.')
+    @debug_token_rendering('Rendering Heading.')
     def render_heading(self, token):
-        self.warnings.add('Markdown Headings are not implemented yet. It will be ignored')
-        return ''
+        style = getattr(self.style, 'header' + str(token.level))
+        return make_paragraph(style, self.render_inner(token))
 
     @debug_token_rendering('Rendering Paragraph.')
     def render_paragraph(self, token):

--- a/source/docx_generator/docx_generator.py
+++ b/source/docx_generator/docx_generator.py
@@ -76,7 +76,7 @@ class DocxGenerator(object):
         jinja2_custom_globals = Globals(base_path, template, jinja2_environment)
 
         jinja2_custom_filters.set_available_filters()
-        jinja2_custom_globals.set_available_globals(self._image_handler)
+        jinja2_custom_globals.set_available_globals()
 
     def _recursive_rendering(self, base_path: str, template_path: str, data: Dict, output_path: str, render_level: int):
         render_level += 1

--- a/source/docx_generator/globals/picture_globals.py
+++ b/source/docx_generator/globals/picture_globals.py
@@ -21,6 +21,9 @@
 import logging
 import os
 import re
+import requests
+import shutil
+import uuid
 
 from docx.enum.text import WD_PARAGRAPH_ALIGNMENT
 from docxtpl import DocxTemplate, Subdoc
@@ -33,12 +36,22 @@ class PictureGlobals(object):
     def __init__(self, template: DocxTemplate, base_path: str):
         self._template = template
         self._base_path = base_path
+        self._output_path = None
 
         self._available_alignment_values = []
         for member in WD_PARAGRAPH_ALIGNMENT.__members__:
             self._available_alignment_values.append(member.name)
 
         self._logger = logging.getLogger(__name__)
+
+    def set_template(self, template: DocxTemplate):
+        self._template = template
+
+    def set_base_path(self, base_path: str):
+        self._base_path = base_path
+
+    def set_output_path(self, output_path: str):
+        self._output_path = output_path
 
     def _scale_picture(self, picture, new_width):
         aspect_ratio = float(picture.height) / float(picture.width)

--- a/source/docx_generator/globals/picture_globals.py
+++ b/source/docx_generator/globals/picture_globals.py
@@ -36,7 +36,7 @@ class PictureGlobals(object):
     def __init__(self, template: DocxTemplate, base_path: str):
         self._template = template
         self._base_path = base_path
-        self._output_path = None
+        self._output_path = os.path.join(base_path, 'tmp', 'images')
 
         self._available_alignment_values = []
         for member in WD_PARAGRAPH_ALIGNMENT.__members__:

--- a/source/docx_generator/globals/picture_globals.py
+++ b/source/docx_generator/globals/picture_globals.py
@@ -67,7 +67,12 @@ class PictureGlobals(object):
         last_section = sub_document.sections[-1]
         page_width = last_section.page_width - last_section.left_margin - last_section.right_margin
 
-        picture = sub_document.add_picture(image_filename)
+        try:
+            picture = sub_document.add_picture(image_filename)
+        except Exception as e:
+            self._logger.debug('Error while adding image {}: {}'.format(image_filename, e.__str__()))
+            self._logger.debug('There is a problem sometimes with JPEG-Files and EXIF-Headers, try a PNG instead')
+            raise RenderingError(self._logger, 'Image could not be added (try PNG instead of JPEG): {}'.format(image_filename))
 
         # Scale picture to page dimension if width is bigger than page width
         if picture.width > page_width:


### PR DESCRIPTION
To be able to use images in docx reports and also headers from markdown, I decided to made these few simple changes.
To be able to use it also from DFIR-IRIS, I will also create a pullrequest there.


## HTML-Tags in Links

Some people use HTML-Tags in link descriptions for example to add an Icon or emphasize something. This produces then a corrupt document.xml:
```
<w:r><w:t xml:space="preserve"><i class="icon icon_one" />Some text with a Link: </w:t></w:r>
<w:hyperlink r:id="rId13" w:tgtFrame="_blank"><w:r>
<w:t xml:space="preserve">[DS] siesta.jpg</w:t></w:r></w:hyperlink>
```
Maybe this is elsewhere the case too :thinking: 

## Header Styles

We use a lot of markdown in our reports and therefore also headers, which where just stripped of till now.
I extended the styles with header1 to header5 and the DocxRenderer to use it as all other tags.

## Image-Handler

Since DFIR-IRIS can handle Datastore-Images we also need them in our Reports. Therefore I have implemented an image_handler based on the PictureGlobal which can now handle local and http(s) images.
It downloads all the images and stores them in a subfolder of the generating report and adds them via the already implemented logic.

There is a inconvenience in docx.image.tiff class which also parses EXIF information from JPEG files. In case there is an unreadable or unknown resolution tag, the image cannot be added. I have not spotted this errors with PNGs. Because this costed me quite some time to figure out, i added a little better log and error message.
Open issue: https://github.com/python-openxml/python-docx/issues/1124

Thanks for your work!
Lukas