### PR TITLE
Fix AttributeError in PictureGlobals when alignment value is string

### DIFF
--- a/source/docx_generator/globals/picture_globals.py
+++ b/source/docx_generator/globals/picture_globals.py
@@ -41,7 +41,7 @@ class PictureGlobals(object):
 
         self._available_alignment_values = []
         for member in WD_PARAGRAPH_ALIGNMENT.__members__:
-            self._available_alignment_values.append(member.name)
+            self._available_alignment_values.append(getattr(member, 'name', member))
 
         self._logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
When trying to generate a report on a fresh install (reproduced on multiple environments: RPi5, VM with all hardware/software requirements met, clean installs), I consistently encountered an internal server error when attempting to generate a report for a case using a template.

Upon checking the docker-compose logs, I found the following error trace:
```
iriswebapp_app |   File "/opt/venv/lib/python3.12/site-packages/docx_generator/globals/picture_globals.py", line 44, in __init__
iriswebapp_app |     self._available_alignment_values.append(member.name)
iriswebapp_app |                                             ^^^^^^^^^^^
iriswebapp_app | AttributeError: 'str' object has no attribute 'name'
```
After some digging, I identified the root cause: the loop in picture_globals.py assumes that each member has a .name attribute, which is true for Enum instances but not when member is a plain string. This leads to the crash.

I replaced : 
`self._available_alignment_values.append(member.name)`
by : 
`self._available_alignment_values.append(getattr(member, 'name', member))`

This preserves the expected behavior for Enum values while gracefully handling strings.
Now it works perfectly for me, reports get generated and I get no more internal server errors